### PR TITLE
Core protocol: Data offers wrapper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,5 +23,4 @@ jobs:
         nimble install
 
     - name: Compile Wayland tests
-      run: |
-        nimble test
+      run: nim c tests/test1.nim

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,11 @@ jobs:
     - name: Install Nim
       uses: iffy/install-nim@v5
 
+    - name: Install Wayland compositor and client library
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libwayland-client0 libwayland-egl1 libwayland-dev
+
     - name: Build
       run: |
         nimble install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,28 +13,10 @@ jobs:
     - name: Install Nim
       uses: iffy/install-nim@v5
 
-    - name: Install Wayland compositor and client library
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y weston libwayland-client0 libwayland-egl1 libwayland-dev
-
     - name: Build
       run: |
         nimble install
 
-    - name: Run Wayland test
+    - name: Compile Wayland tests
       run: |
-        set -euo pipefail
-        export XDG_RUNTIME_DIR=/tmp/xdg-runtime
-        mkdir -p "$XDG_RUNTIME_DIR"
-        chmod 700 "$XDG_RUNTIME_DIR"
-        weston --backend=headless-backend.so --socket=wayland-1 --idle-time=0 &
-        WESTON_PID=$!
-        trap "kill $WESTON_PID" EXIT
-        for _ in $(seq 1 50); do
-          if [ -S "$XDG_RUNTIME_DIR/wayland-1" ]; then
-            break
-          fi
-          sleep 0.1
-        done
-        WAYLAND_DISPLAY=wayland-1 nim c -r tests/test1.nim
+        nimble test

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ $ nimble add https://github.com/xTrayambak/nayland
 - [X] `wl_buffer`
 - [X] `wl_callback`
 - [X] `wl_shm_pool`
-- [ ] `wl_data_offer`
-- [ ] `wl_data_source`
-- [ ] `wl_data_device`
-- [ ] `wl_data_device_manager`
+- [X] `wl_data_offer`
+- [X] `wl_data_source`
+- [X] `wl_data_device`
+- [X] `wl_data_device_manager`
 - [X] `wl_seat`
 - [X] `wl_pointer`
 - [X] `wl_keyboard`

--- a/src/nayland/bindings/protocols/core.nim
+++ b/src/nayland/bindings/protocols/core.nim
@@ -121,10 +121,10 @@ type
 
   wl_data_source_listener* {.importc: "struct $1".} = object
     target*:
-      proc(data: pointer, source: ptr wl_data_source, mimeType: cstring) {.cdecl.}
-    send*: proc(data: pointer, source: ptr wl_data_source, mimeType: cstring, fd: int32) {.
-      cdecl
-    .}
+      proc(data: pointer, source: ptr wl_data_source, mimeType: ConstCStr) {.cdecl.}
+    send*: proc(
+      data: pointer, source: ptr wl_data_source, mimeType: ConstCStr, fd: int32
+    ) {.cdecl.}
     cancelled*: proc(data: pointer, source: ptr wl_data_source) {.cdecl.}
     dnd_drop_performed*: proc(data: pointer, source: ptr wl_data_source) {.cdecl.}
     dnd_finished*: proc(data: pointer, source: ptr wl_data_source) {.cdecl.}
@@ -244,6 +244,9 @@ proc wl_data_device_manager_get_data_device*(
 proc wl_data_source_destroy*(src: ptr wl_data_source)
 proc wl_data_source_offer*(src: ptr wl_data_source, mimeType: cstring)
 proc wl_data_source_set_actions*(src: ptr wl_data_source, dndActions: uint32)
+proc wl_data_source_add_listener*(
+  src: ptr wl_data_source, listener: ptr wl_data_source_listener, cookie: pointer
+): int32
 
 proc wl_data_device_start_drag*(
   dev: ptr wl_data_device,

--- a/src/nayland/bindings/protocols/core.nim
+++ b/src/nayland/bindings/protocols/core.nim
@@ -30,6 +30,10 @@ type
   wl_pointer* {.importc: "struct $1".} = object
   wl_callback* {.importc: "struct $1".} = object
   wl_keyboard* {.importc: "struct $1".} = object
+  wl_data_offer* {.importc: "struct $1".} = object
+  wl_data_source* {.importc: "struct $1".} = object
+  wl_data_device* {.importc: "struct $1".} = object
+  wl_data_device_manager* {.importc: "struct $1".} = object
 
   wl_pointer_listener* {.importc: "struct $1".} = object
     enter*: proc(
@@ -108,6 +112,9 @@ type
 
   wl_buffer_listener* {.importc: "struct $1".} = object
     release*: proc(data: pointer, buffer: ptr wl_buffer) {.cdecl.}
+
+  wl_data_device_listener* {.importc: "struct $1".} = object
+    offer*: proc(mimeType: cstring) {.cdecl.}
 
 {.push importc.}
 
@@ -189,6 +196,39 @@ proc wl_keyboard_release*(keyb: ptr wl_keyboard)
 proc wl_keyboard_add_listener*(
   keyb: ptr wl_keyboard, listener: ptr wl_keyboard_listener, data: pointer
 ): int32
+
+proc wl_data_device_manager_create_data_source*(
+  mgr: ptr wl_data_device_manager
+): ptr wl_data_source
+
+proc wl_data_device_manager_get_data_device*(
+  mgr: ptr wl_data_device_manager, seat: ptr wl_seat
+): ptr wl_data_device
+
+proc wl_data_source_destroy*(src: ptr wl_data_source)
+proc wl_data_source_offer*(src: ptr wl_data_source, mimeType: cstring)
+proc wl_data_source_set_actions*(src: ptr wl_data_source, dndActions: uint32)
+
+proc wl_data_device_start_drag*(
+  dev: ptr wl_data_device,
+  src: ptr wl_data_source,
+  origin, icon: ptr wl_surface,
+  serial: uint32,
+)
+
+proc wl_data_device_set_selection*(
+  dev: ptr wl_data_device, src: ptr wl_data_source, serial: uint32
+)
+
+proc wl_data_device_release*(dev: ptr wl_data_device)
+
+proc wl_data_offer_destroy*(offer: ptr wl_data_offer)
+proc wl_data_offer_accept*(offer: ptr wl_data_offer, serial: uint32, mime: cstring)
+proc wl_data_offer_receive*(offer: ptr wl_data_offer, mime: cstring, fd: int32)
+proc wl_data_offer_finish*(offer: ptr wl_data_offer)
+proc wl_data_offer_set_actions*(
+  offer: ptr wl_data_offer, dndActions, preferredActions: uint32
+)
 
 # Core Wayland protocol interfaces
 let wl_compositor_interface*: wl_interface

--- a/src/nayland/bindings/protocols/core.nim
+++ b/src/nayland/bindings/protocols/core.nim
@@ -113,8 +113,42 @@ type
   wl_buffer_listener* {.importc: "struct $1".} = object
     release*: proc(data: pointer, buffer: ptr wl_buffer) {.cdecl.}
 
+  wl_data_offer_listener* {.importc: "struct $1".} = object
+    offer*: proc(data: pointer, offer: ptr wl_data_offer, mimeType: ConstCStr) {.cdecl.}
+    source_actions*:
+      proc(data: pointer, offer: ptr wl_data_offer, actions: uint32) {.cdecl.}
+    action*: proc(data: pointer, offer: ptr wl_data_offer, dndAction: uint32) {.cdecl.}
+
+  wl_data_source_listener* {.importc: "struct $1".} = object
+    target*:
+      proc(data: pointer, source: ptr wl_data_source, mimeType: cstring) {.cdecl.}
+    send*: proc(data: pointer, source: ptr wl_data_source, mimeType: cstring, fd: int32) {.
+      cdecl
+    .}
+    cancelled*: proc(data: pointer, source: ptr wl_data_source) {.cdecl.}
+    dnd_drop_performed*: proc(data: pointer, source: ptr wl_data_source) {.cdecl.}
+    dnd_finished*: proc(data: pointer, source: ptr wl_data_source) {.cdecl.}
+    action*:
+      proc(data: pointer, source: ptr wl_data_source, dndAction: uint32) {.cdecl.}
+
   wl_data_device_listener* {.importc: "struct $1".} = object
-    offer*: proc(mimeType: cstring) {.cdecl.}
+    data_offer*: proc(
+      data: pointer, source: ptr wl_data_device, offer: ptr wl_data_offer
+    ) {.cdecl.}
+    enter*: proc(
+      data: pointer,
+      source: ptr wl_data_device,
+      serial: uint32,
+      surface: ptr wl_surface,
+      x, y: wl_fixed,
+      offer: ptr wl_data_offer,
+    ) {.cdecl.}
+    leave*: proc(data: pointer, source: ptr wl_data_device) {.cdecl.}
+    motion*: proc(data: pointer, source: ptr wl_data_device, x, y: wl_fixed) {.cdecl.}
+    drop*: proc(data: pointer, source: ptr wl_data_device) {.cdecl.}
+    selection*: proc(
+      data: pointer, source: ptr wl_data_device, offer: ptr wl_data_offer
+    ) {.cdecl.}
 
 {.push importc.}
 
@@ -229,6 +263,10 @@ proc wl_data_offer_finish*(offer: ptr wl_data_offer)
 proc wl_data_offer_set_actions*(
   offer: ptr wl_data_offer, dndActions, preferredActions: uint32
 )
+
+proc wl_data_offer_add_listener*(
+  o: ptr wl_data_offer, l: ptr wl_data_offer_listener, data: pointer
+): int32
 
 # Core Wayland protocol interfaces
 let wl_compositor_interface*: wl_interface

--- a/src/nayland/bindings/protocols/core.nim
+++ b/src/nayland/bindings/protocols/core.nim
@@ -144,7 +144,9 @@ type
       offer: ptr wl_data_offer,
     ) {.cdecl.}
     leave*: proc(data: pointer, source: ptr wl_data_device) {.cdecl.}
-    motion*: proc(data: pointer, source: ptr wl_data_device, x, y: wl_fixed) {.cdecl.}
+    motion*: proc(
+      data: pointer, source: ptr wl_data_device, serial: uint32, x, y: wl_fixed
+    ) {.cdecl.}
     drop*: proc(data: pointer, source: ptr wl_data_device) {.cdecl.}
     selection*: proc(
       data: pointer, source: ptr wl_data_device, offer: ptr wl_data_offer
@@ -253,6 +255,10 @@ proc wl_data_device_start_drag*(
 proc wl_data_device_set_selection*(
   dev: ptr wl_data_device, src: ptr wl_data_source, serial: uint32
 )
+
+proc wl_data_device_add_listener*(
+  o: ptr wl_data_device, l: ptr wl_data_device_listener, data: pointer
+): int32
 
 proc wl_data_device_release*(dev: ptr wl_data_device)
 

--- a/src/nayland/types/protocols/core/data_device.nim
+++ b/src/nayland/types/protocols/core/data_device.nim
@@ -1,0 +1,30 @@
+## Wrapper around `wl_data_device`
+##
+## Copyright (C) 2026 Trayambak Rai (xtrayambak@disroot.org)
+import pkg/nayland/bindings/protocols/core
+import pkg/nayland/types/protocols/core/[data_source, surface]
+
+type
+  DataDeviceObj = object
+    handle: ptr wl_data_device
+
+  DataDevice* = ref DataDeviceObj
+
+proc `=destroy`*(device: DataDeviceObj) =
+  discard # No-op
+
+proc startDrag*(
+    device: DataDevice, source: DataSource, origin, icon: Surface, serial: uint32
+) =
+  wl_data_device_start_drag(
+    device.handle, source.handle, origin.handle, icon.handle, serial
+  )
+
+proc setSelection*(device: DataDevice, source: DataSource, serial: uint32) =
+  wl_data_device_set_selection(device.handle, source.handle, serial)
+
+proc release*(device: DataDevice) =
+  wl_data_device_release(device.handle)
+
+func newDataDevice*(handle: ptr wl_data_device): DataDevice =
+  DataDevice(handle: handle)

--- a/src/nayland/types/protocols/core/data_device.nim
+++ b/src/nayland/types/protocols/core/data_device.nim
@@ -1,17 +1,81 @@
 ## Wrapper around `wl_data_device`
 ##
 ## Copyright (C) 2026 Trayambak Rai (xtrayambak@disroot.org)
-import pkg/nayland/bindings/protocols/core
-import pkg/nayland/types/protocols/core/[data_source, surface]
+import pkg/nayland/bindings/protocols/core, pkg/nayland/bindings/libwayland
+import pkg/nayland/types/protocols/core/[data_source, data_offer, surface]
 
 type
   DataDeviceObj = object
     handle: ptr wl_data_device
+    payload: DataDevicePayload
+
+  DataDeviceDataOfferCallback = proc(device: DataDevice, offer: DataOffer)
+  DataDeviceEnterCallback = proc(
+    device: DataDevice, serial: uint32, surface: Surface, x, y: float, offer: DataOffer
+  )
+  DataDeviceLeaveCallback = proc(device: DataDevice)
+  DataDeviceMotionCallback = proc(device: DataDevice, serial: uint32, x, y: float)
+  DataDeviceDropCallback = proc(device: DataDevice)
+  DataDeviceSelectionCallback = proc(device: DataDevice, offer: DataOffer)
+
+  DataDevicePObj = object
+    dataOfferCb*: DataDeviceDataOfferCallback
+    enterCb*: DataDeviceEnterCallback
+    leaveCb*: DataDeviceLeaveCallback
+    motionCb*: DataDeviceMotionCallback
+    dropCb*: DataDeviceDropCallback
+    selectionCb*: DataDeviceSelectionCallback
+
+  DataDevicePayload = ref DataDevicePObj
 
   DataDevice* = ref DataDeviceObj
 
 proc `=destroy`*(device: DataDeviceObj) =
   discard # No-op
+
+func newDataDevice*(handle: ptr wl_data_device): DataDevice {.inline.} =
+  DataDevice(handle: handle, payload: DataDevicePayload())
+
+let listener = wl_data_device_listener(
+  data_offer: proc(
+      data: pointer, device: ptr wl_data_device, offer: ptr wl_data_offer
+  ) {.cdecl.} =
+    let payload = cast[DataDevicePayload](data)
+    payload.dataOfferCb(newDataDevice(device), newDataOffer(offer)),
+  enter: proc(
+      data: pointer,
+      device: ptr wl_data_device,
+      serial: uint32,
+      surface: ptr wl_surface,
+      x, y: wl_fixed,
+      offer: ptr wl_data_offer,
+  ) {.cdecl.} =
+    let payload = cast[DataDevicePayload](data)
+    payload.enterCb(
+      newDataDevice(device),
+      serial,
+      newSurface(surface),
+      x.toFloat(),
+      y.toFloat(),
+      newDataOffer(offer),
+    ),
+  leave: proc(data: pointer, device: ptr wl_data_device) {.cdecl.} =
+    let payload = cast[DataDevicePayload](data)
+    payload.leaveCb(newDataDevice(device)),
+  motion: proc(
+      data: pointer, source: ptr wl_data_device, serial: uint32, x, y: wl_fixed
+  ) {.cdecl.} =
+    let payload = cast[DataDevicePayload](data)
+    payload.motionCb(newDataDevice(source), serial, x.toFloat(), y.toFloat()),
+  drop: proc(data: pointer, source: ptr wl_data_device) {.cdecl.} =
+    let payload = cast[DataDevicePayload](data)
+    payload.dropCb(newDataDevice(source)),
+  selection: proc(
+      data: pointer, source: ptr wl_data_device, offer: ptr wl_data_offer
+  ) {.cdecl.} =
+    let payload = cast[DataDevicePayload](data)
+    payload.selectionCb(newDataDevice(source), newDataOffer(offer)),
+)
 
 proc startDrag*(
     device: DataDevice, source: DataSource, origin, icon: Surface, serial: uint32
@@ -23,8 +87,28 @@ proc startDrag*(
 proc setSelection*(device: DataDevice, source: DataSource, serial: uint32) =
   wl_data_device_set_selection(device.handle, source.handle, serial)
 
+func `onDataOffer=`*(device: DataDevice, cb: DataDeviceDataOfferCallback) =
+  device.payload.dataOfferCb = cb
+
+func `onEnter=`*(device: DataDevice, cb: DataDeviceEnterCallback) =
+  device.payload.enterCb = cb
+
+func `onLeave=`*(device: DataDevice, cb: DataDeviceLeaveCallback) =
+  device.payload.leaveCb = cb
+
+func `onMotion=`*(device: DataDevice, cb: DataDeviceMotionCallback) =
+  device.payload.motionCb = cb
+
+func `onDrop=`*(device: DataDevice, cb: DataDeviceDropCallback) =
+  device.payload.dropCb = cb
+
+func `onSelection=`*(device: DataDevice, cb: DataDeviceSelectionCallback) =
+  device.payload.selectionCb = cb
+
+proc attachCallbacks*(device: DataDevice) =
+  discard wl_data_device_add_listener(
+    device.handle, listener.addr, cast[pointer](device.payload)
+  )
+
 proc release*(device: DataDevice) =
   wl_data_device_release(device.handle)
-
-func newDataDevice*(handle: ptr wl_data_device): DataDevice =
-  DataDevice(handle: handle)

--- a/src/nayland/types/protocols/core/data_device_manager.nim
+++ b/src/nayland/types/protocols/core/data_device_manager.nim
@@ -1,0 +1,21 @@
+## Wrapper around `wl_data_device_manager`
+## 
+## Copyright (C) 2026 Trayambak Rai (xtrayambak@disroot.org)
+import
+  pkg/nayland/bindings/protocols/core,
+  pkg/nayland/types/protocols/core/[data_device, data_source, seat]
+
+type
+  DataDeviceManagerObj = object
+    handle: ptr wl_data_device_manager
+
+  DataDeviceManager* = ref DataDeviceManagerObj
+
+proc `=destroy`(mgr: DataDeviceManagerObj) =
+  discard # No-op
+
+proc createDataSource*(manager: DataDeviceManager): DataSource =
+  newDataSource(wl_data_device_manager_create_data_source(manager.handle))
+
+proc getDataDevice*(manager: DataDeviceManager, seat: Seat): DataDevice =
+  newDataDevice(wl_data_device_manager_get_data_device(manager.handle, seat.handle))

--- a/src/nayland/types/protocols/core/data_device_manager.nim
+++ b/src/nayland/types/protocols/core/data_device_manager.nim
@@ -19,3 +19,6 @@ proc createDataSource*(manager: DataDeviceManager): DataSource =
 
 proc getDataDevice*(manager: DataDeviceManager, seat: Seat): DataDevice =
   newDataDevice(wl_data_device_manager_get_data_device(manager.handle, seat.handle))
+
+func initDataDeviceManager*(handle: pointer): DataDeviceManager =
+  DataDeviceManager(handle: cast[ptr wl_data_device_manager](handle))

--- a/src/nayland/types/protocols/core/data_offer.nim
+++ b/src/nayland/types/protocols/core/data_offer.nim
@@ -1,0 +1,28 @@
+## Wrapper around `wl_data_offer`
+##
+## Copyright (C) 2026 Trayambak Rai (xtrayambak@disroot.org)
+import pkg/nayland/bindings/protocols/core
+import pkg/nayland/types/protocols/core/data_source
+
+type
+  DataOfferObj = object
+    handle: ptr wl_data_offer
+
+  DataOffer* = ref DataOfferObj
+
+proc `=destroy`*(offer: DataOfferObj) =
+  wl_data_offer_destroy(offer.handle)
+
+proc accept*(offer: DataOffer, serial: uint32, mimeType: string) =
+  wl_data_offer_accept(offer.handle, serial, cstring(mimeType))
+
+proc receive*(offer: DataOffer, mimeType: string, fd: int32) =
+  wl_data_offer_receive(offer.handle, cstring(mimeType), fd)
+
+proc finish*(offer: DataOffer) =
+  wl_data_offer_finish(offer.handle)
+
+proc setActions*(offer: DataOffer, dndActions, preferredActions: set[DNDAction]) =
+  wl_data_offer_set_actions(
+    offer.handle, cast[uint32](dndActions), cast[uint32](preferredActions)
+  )

--- a/src/nayland/types/protocols/core/data_offer.nim
+++ b/src/nayland/types/protocols/core/data_offer.nim
@@ -1,17 +1,44 @@
 ## Wrapper around `wl_data_offer`
 ##
 ## Copyright (C) 2026 Trayambak Rai (xtrayambak@disroot.org)
-import pkg/nayland/bindings/protocols/core
+import pkg/nayland/bindings/protocols/core, pkg/nayland/bindings/libwayland
 import pkg/nayland/types/protocols/core/data_source
 
 type
   DataOfferObj = object
     handle: ptr wl_data_offer
+    payload: DataOfferPayload
+
+  DataOfferOfferCallback = proc(offer: DataOffer, mimeType: string)
+  DataOfferSourceActionsCallback = proc(offer: DataOffer, actions: set[DNDAction])
+  DataOfferActionCallback = proc(offer: DataOffer, dndAction: set[DNDAction])
+    # TODO: is this a bitset or just a singular DNDAction?
+
+  DataOfferPObj = object
+    offerCb*: DataOfferOfferCallback
+    sourceActionsCb*: DataOfferSourceActionsCallback
+    actionCb*: DataOfferActionCallback
+
+  DataOfferPayload = ref DataOfferPObj
 
   DataOffer* = ref DataOfferObj
 
 proc `=destroy`*(offer: DataOfferObj) =
   wl_data_offer_destroy(offer.handle)
+
+let listener = wl_data_offer_listener(
+  offer: proc(data: pointer, offer: ptr wl_data_offer, mime: ConstCStr) {.cdecl.} =
+    let payload = cast[DataOfferPayload](data)
+    payload.offerCb(DataOffer(handle: offer), $mime),
+  source_actions: proc(
+      data: pointer, offer: ptr wl_data_offer, actions: uint32
+  ) {.cdecl.} =
+    let payload = cast[DataOfferPayload](data)
+    payload.sourceActionsCb(DataOffer(handle: offer), cast[set[DNDAction]](actions)),
+  action: proc(data: pointer, offer: ptr wl_data_offer, dndAction: uint32) {.cdecl.} =
+    let payload = cast[DataOfferPayload](data)
+    payload.actionCb(DataOffer(handle: offer), cast[set[DNDAction]](dndAction)),
+)
 
 proc accept*(offer: DataOffer, serial: uint32, mimeType: string) =
   wl_data_offer_accept(offer.handle, serial, cstring(mimeType))
@@ -22,7 +49,24 @@ proc receive*(offer: DataOffer, mimeType: string, fd: int32) =
 proc finish*(offer: DataOffer) =
   wl_data_offer_finish(offer.handle)
 
+func `onOffer=`*(offer: DataOffer, cb: DataOfferOfferCallback) =
+  offer.payload.offerCb = cb
+
+func `onSourceActions=`*(offer: DataOffer, cb: DataOfferSourceActionsCallback) =
+  offer.payload.sourceActionsCb = cb
+
+func `onAction=`*(offer: DataOffer, cb: DataOfferActionCallback) =
+  offer.payload.actionCb = cb
+
+proc attachCallbacks*(offer: DataOffer) =
+  discard wl_data_offer_add_listener(
+    offer.handle, listener.addr, cast[pointer](offer.payload)
+  )
+
 proc setActions*(offer: DataOffer, dndActions, preferredActions: set[DNDAction]) =
   wl_data_offer_set_actions(
     offer.handle, cast[uint32](dndActions), cast[uint32](preferredActions)
   )
+
+func newDataOffer*(handle: ptr wl_data_offer): DataOffer =
+  DataOffer(handle: handle, payload: DataOfferPayload())

--- a/src/nayland/types/protocols/core/data_offer.nim
+++ b/src/nayland/types/protocols/core/data_offer.nim
@@ -26,18 +26,21 @@ type
 proc `=destroy`*(offer: DataOfferObj) =
   wl_data_offer_destroy(offer.handle)
 
+func newDataOffer*(handle: ptr wl_data_offer): DataOffer {.inline.} =
+  DataOffer(handle: handle, payload: DataOfferPayload())
+
 let listener = wl_data_offer_listener(
   offer: proc(data: pointer, offer: ptr wl_data_offer, mime: ConstCStr) {.cdecl.} =
     let payload = cast[DataOfferPayload](data)
-    payload.offerCb(DataOffer(handle: offer), $mime),
+    payload.offerCb(newDataOffer(offer), $mime),
   source_actions: proc(
       data: pointer, offer: ptr wl_data_offer, actions: uint32
   ) {.cdecl.} =
     let payload = cast[DataOfferPayload](data)
-    payload.sourceActionsCb(DataOffer(handle: offer), cast[set[DNDAction]](actions)),
+    payload.sourceActionsCb(newDataOffer(offer), cast[set[DNDAction]](actions)),
   action: proc(data: pointer, offer: ptr wl_data_offer, dndAction: uint32) {.cdecl.} =
     let payload = cast[DataOfferPayload](data)
-    payload.actionCb(DataOffer(handle: offer), cast[set[DNDAction]](dndAction)),
+    payload.actionCb(newDataOffer(offer), cast[set[DNDAction]](dndAction)),
 )
 
 proc accept*(offer: DataOffer, serial: uint32, mimeType: string) =
@@ -67,6 +70,3 @@ proc setActions*(offer: DataOffer, dndActions, preferredActions: set[DNDAction])
   wl_data_offer_set_actions(
     offer.handle, cast[uint32](dndActions), cast[uint32](preferredActions)
   )
-
-func newDataOffer*(handle: ptr wl_data_offer): DataOffer =
-  DataOffer(handle: handle, payload: DataOfferPayload())

--- a/src/nayland/types/protocols/core/data_source.nim
+++ b/src/nayland/types/protocols/core/data_source.nim
@@ -1,0 +1,28 @@
+## Wrapper around `wl_data_source`
+##
+## Copyright (C) 2026 Trayambak Rai (xtrayambak@disroot.org)
+import pkg/nayland/bindings/protocols/core
+
+type
+  DataSourceObj = object
+    handle*: ptr wl_data_source
+
+  DNDAction* {.pure, size: sizeof(uint32).} = enum
+    None = 0
+    Copy = 1
+    Move = 2
+    Ask = 4
+
+  DataSource* = ref DataSourceObj
+
+proc `=destroy`*(source: DataSourceObj) =
+  wl_data_source_destroy(source.handle)
+
+proc offer*(source: DataSource, mime: string) =
+  wl_data_source_offer(source.handle, cstring(mime))
+
+proc setActions*(source: DataSource, actions: set[DNDAction]) =
+  wl_data_source_set_actions(source.handle, cast[uint32](actions))
+
+func newDataSource*(handle: ptr wl_data_source): DataSource =
+  DataSource(handle: handle)

--- a/src/nayland/types/protocols/core/data_source.nim
+++ b/src/nayland/types/protocols/core/data_source.nim
@@ -1,11 +1,29 @@
 ## Wrapper around `wl_data_source`
 ##
 ## Copyright (C) 2026 Trayambak Rai (xtrayambak@disroot.org)
-import pkg/nayland/bindings/protocols/core
+import pkg/nayland/bindings/protocols/core, pkg/nayland/bindings/libwayland
 
 type
   DataSourceObj = object
     handle*: ptr wl_data_source
+    payload: DataSourcePayload
+
+  DataSourceTargetCallback = proc(source: DataSource, mimeType: string)
+  DataSourceSendCallback = proc(source: DataSource, mimeType: string, fd: int32)
+  DataSourceCancelledCallback = proc(source: DataSource)
+  DataSourceDNDDropPerformedCallback = DataSourceCancelledCallback
+  DataSourceDNDFinishedCallback = DataSourceCancelledCallback
+  DataSourceActionCallback = proc(source: DataSource, action: DNDAction)
+
+  DataSourcePObj = object
+    targetCb*: DataSourceTargetCallback
+    sendCb*: DataSourceSendCallback
+    cancelledCb*: DataSourceCancelledCallback
+    dndDropPerformedCb*: DataSourceDNDDropPerformedCallback
+    dndFinishedCb*: DataSourceDNDFinishedCallback
+    actionCb*: DataSourceActionCallback
+
+  DataSourcePayload = ref DataSourcePObj
 
   DNDAction* {.pure, size: sizeof(uint32).} = enum
     None = 0
@@ -18,11 +36,61 @@ type
 proc `=destroy`*(source: DataSourceObj) =
   wl_data_source_destroy(source.handle)
 
+func newDataSource*(handle: ptr wl_data_source): DataSource {.inline.} =
+  DataSource(handle: handle, payload: DatasourcePayload())
+
+let listener = wl_data_source_listener(
+  target: proc(
+      data: pointer, source: ptr wl_data_source, mimeType: ConstCStr
+  ) {.cdecl.} =
+    let payload = cast[DataSourcePayload](data)
+    payload.targetCb(newDataSource(source), $mimeType),
+  send: proc(
+      data: pointer, source: ptr wl_data_source, mimeType: ConstCStr, fd: int32
+  ) {.cdecl.} =
+    let payload = cast[DataSourcePayload](data)
+    payload.sendCb(newDataSource(source), $mimeType, fd),
+  cancelled: proc(data: pointer, source: ptr wl_data_source) {.cdecl.} =
+    let payload = cast[DataSourcePayload](data)
+    payload.cancelledCb(newDataSource(source)),
+  dnd_drop_performed: proc(data: pointer, source: ptr wl_data_source) {.cdecl.} =
+    let payload = cast[DataSourcePayload](data)
+    payload.dndDropPerformedCb(newDataSource(source)),
+  dnd_finished: proc(data: pointer, source: ptr wl_data_source) {.cdecl.} =
+    let payload = cast[DataSourcePayload](data)
+    payload.dndFinishedCb(newDataSource(source)),
+  action: proc(data: pointer, source: ptr wl_data_source, dndAction: uint32) {.cdecl.} =
+    let payload = cast[DataSourcePayload](data)
+    payload.actionCb(newDataSource(source), cast[DNDAction](dndAction)),
+)
+
+func `onTarget=`*(source: DataSource, cb: DataSourceTargetCallback) =
+  source.payload.targetCb = cb
+
+func `onSend=`*(source: DataSource, cb: DataSourceSendCallback) =
+  source.payload.sendCb = cb
+
+func `onCancelled=`*(source: DataSource, cb: DataSourceCancelledCallback) =
+  source.payload.cancelledCb = cb
+
+func `onDndDropPerformed=`*(
+    source: DataSource, cb: DataSourceDNDDropPerformedCallback
+) =
+  source.payload.dndDropPerformedCb = cb
+
+func `onDndFinished=`*(source: DataSource, cb: DataSourceDNDFinishedCallback) =
+  source.payload.dndFinishedCb = cb
+
+func `onAction=`*(source: DataSource, cb: DataSourceActionCallback) =
+  source.payload.actionCb = cb
+
+proc attachCallbacks*(source: DataSource) =
+  discard wl_data_source_add_listener(
+    source.handle, listener.addr, cast[pointer](source.payload)
+  )
+
 proc offer*(source: DataSource, mime: string) =
   wl_data_source_offer(source.handle, cstring(mime))
 
 proc setActions*(source: DataSource, actions: set[DNDAction]) =
   wl_data_source_set_actions(source.handle, cast[uint32](actions))
-
-func newDataSource*(handle: ptr wl_data_source): DataSource =
-  DataSource(handle: handle)

--- a/src/nayland/types/protocols/core/prelude.nim
+++ b/src/nayland/types/protocols/core/prelude.nim
@@ -1,0 +1,10 @@
+## Prelude file to import the entirity of the Wayland core protocol
+import
+  pkg/nayland/types/protocols/core/[
+    buffer, callback, compositor, data_device, data_device_manager, data_offer,
+    data_source, keyboard, pointer, region, registry, seat, shm, shm_pool, surface,
+  ]
+
+export
+  buffer, callback, compositor, data_device, data_device_manager, data_offer,
+  data_source, keyboard, pointer, region, registry, seat, shm, shm_pool, surface

--- a/src/nayland/types/protocols/core/seat.nim
+++ b/src/nayland/types/protocols/core/seat.nim
@@ -7,7 +7,7 @@ import pkg/nayland/types/protocols/core/[keyboard, pointer]
 
 type
   SeatObj = object
-    handle: ptr wl_seat
+    handle*: ptr wl_seat
 
   Seat* = ref SeatObj
 

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -1,10 +1,7 @@
 import std/[tables, posix, options]
 import
   pkg/nayland/types/display,
-  pkg/nayland/types/protocols/core/[
-    buffer, callback, compositor, keyboard, pointer, registry, seat, shm, shm_pool,
-    surface,
-  ],
+  pkg/nayland/types/protocols/core/prelude,
   pkg/nayland/bindings/protocols/[core, xdg_shell, fractional_scale_v1],
   pkg/nayland/types/protocols/xdg_shell/[wm_base, xdg_surface, xdg_toplevel],
   pkg/nayland/types/protocols/fractional_scale/prelude


### PR DESCRIPTION
- **add: core: implement all `wl_data_*` types**
- **add: core: `DataOffer` callbacks implementation**
- **fix: core: `DataOffer` callbacks should use `newDataOffer()`**
- **add: core: `DataDevice` callbacks implementation**
- **add: core: `DataSource` callbacks implementation**

Self-explanatory.
