### PR TITLE
Added guards checking if there are actually callbacks registered

### DIFF
--- a/src/nayland/types/protocols/core/data_device.nim
+++ b/src/nayland/types/protocols/core/data_device.nim
@@ -33,15 +33,15 @@ type
 proc `=destroy`*(device: DataDeviceObj) =
   discard # No-op
 
-func newDataDevice*(handle: ptr wl_data_device): DataDevice {.inline.} =
-  DataDevice(handle: handle, payload: DataDevicePayload())
+proc newDataDevice*(handle: ptr wl_data_device): DataDevice {.inline.}
 
 let listener = wl_data_device_listener(
   data_offer: proc(
       data: pointer, device: ptr wl_data_device, offer: ptr wl_data_offer
   ) {.cdecl.} =
     let payload = cast[DataDevicePayload](data)
-    payload.dataOfferCb(newDataDevice(device), newDataOffer(offer)),
+    if payload.dataOfferCb != nil:
+      payload.dataOfferCb(newDataDevice(device), newDataOffer(offer)),
   enter: proc(
       data: pointer,
       device: ptr wl_data_device,
@@ -51,30 +51,35 @@ let listener = wl_data_device_listener(
       offer: ptr wl_data_offer,
   ) {.cdecl.} =
     let payload = cast[DataDevicePayload](data)
-    payload.enterCb(
-      newDataDevice(device),
-      serial,
-      newSurface(surface),
-      x.toFloat(),
-      y.toFloat(),
-      newDataOffer(offer),
-    ),
+    if payload.enterCb != nil:
+      payload.enterCb(
+        newDataDevice(device),
+        serial,
+        newSurface(surface),
+        x.toFloat(),
+        y.toFloat(),
+        newDataOffer(offer),
+      ),
   leave: proc(data: pointer, device: ptr wl_data_device) {.cdecl.} =
     let payload = cast[DataDevicePayload](data)
-    payload.leaveCb(newDataDevice(device)),
+    if payload.leaveCb != nil:
+      payload.leaveCb(newDataDevice(device)),
   motion: proc(
       data: pointer, source: ptr wl_data_device, serial: uint32, x, y: wl_fixed
   ) {.cdecl.} =
     let payload = cast[DataDevicePayload](data)
-    payload.motionCb(newDataDevice(source), serial, x.toFloat(), y.toFloat()),
+    if payload.motionCb != nil:
+      payload.motionCb(newDataDevice(source), serial, x.toFloat(), y.toFloat()),
   drop: proc(data: pointer, source: ptr wl_data_device) {.cdecl.} =
     let payload = cast[DataDevicePayload](data)
-    payload.dropCb(newDataDevice(source)),
+    if payload.dropCb != nil:
+      payload.dropCb(newDataDevice(source)),
   selection: proc(
       data: pointer, source: ptr wl_data_device, offer: ptr wl_data_offer
   ) {.cdecl.} =
     let payload = cast[DataDevicePayload](data)
-    payload.selectionCb(newDataDevice(source), newDataOffer(offer)),
+    if payload.selectionCb != nil:
+      payload.selectionCb(newDataDevice(source), newDataOffer(offer)),
 )
 
 proc startDrag*(
@@ -105,10 +110,14 @@ func `onDrop=`*(device: DataDevice, cb: DataDeviceDropCallback) =
 func `onSelection=`*(device: DataDevice, cb: DataDeviceSelectionCallback) =
   device.payload.selectionCb = cb
 
-proc attachCallbacks*(device: DataDevice) =
-  discard wl_data_device_add_listener(
-    device.handle, listener.addr, cast[pointer](device.payload)
-  )
+proc attachCallbacks*(device: DataDevice) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".}
+  discard
 
 proc release*(device: DataDevice) =
   wl_data_device_release(device.handle)
+
+proc newDataDevice*(handle: ptr wl_data_device): DataDevice {.inline.} =
+  result = DataDevice(handle: handle, payload: DataDevicePayload())
+  discard wl_data_device_add_listener(
+    result.handle, listener.addr, cast[pointer](result.payload)
+  )

--- a/src/nayland/types/protocols/core/data_device.nim
+++ b/src/nayland/types/protocols/core/data_device.nim
@@ -110,7 +110,7 @@ func `onDrop=`*(device: DataDevice, cb: DataDeviceDropCallback) =
 func `onSelection=`*(device: DataDevice, cb: DataDeviceSelectionCallback) =
   device.payload.selectionCb = cb
 
-proc attachCallbacks*(device: DataDevice) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".}
+proc attachCallbacks*(device: DataDevice) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".} =
   discard
 
 proc release*(device: DataDevice) =

--- a/src/nayland/types/protocols/core/data_offer.nim
+++ b/src/nayland/types/protocols/core/data_offer.nim
@@ -26,21 +26,23 @@ type
 proc `=destroy`*(offer: DataOfferObj) =
   wl_data_offer_destroy(offer.handle)
 
-func newDataOffer*(handle: ptr wl_data_offer): DataOffer {.inline.} =
-  DataOffer(handle: handle, payload: DataOfferPayload())
+proc newDataOffer*(handle: ptr wl_data_offer): DataOffer {.inline.}
 
 let listener = wl_data_offer_listener(
   offer: proc(data: pointer, offer: ptr wl_data_offer, mime: ConstCStr) {.cdecl.} =
     let payload = cast[DataOfferPayload](data)
-    payload.offerCb(newDataOffer(offer), $mime),
+    if payload.offerCb != nil:
+      payload.offerCb(newDataOffer(offer), $mime),
   source_actions: proc(
       data: pointer, offer: ptr wl_data_offer, actions: uint32
   ) {.cdecl.} =
     let payload = cast[DataOfferPayload](data)
-    payload.sourceActionsCb(newDataOffer(offer), cast[set[DNDAction]](actions)),
+    if payload.sourceActionsCb != nil:
+      payload.sourceActionsCb(newDataOffer(offer), cast[set[DNDAction]](actions)),
   action: proc(data: pointer, offer: ptr wl_data_offer, dndAction: uint32) {.cdecl.} =
     let payload = cast[DataOfferPayload](data)
-    payload.actionCb(newDataOffer(offer), cast[set[DNDAction]](dndAction)),
+    if payload.actionCb != nil:
+      payload.actionCb(newDataOffer(offer), cast[set[DNDAction]](dndAction)),
 )
 
 proc accept*(offer: DataOffer, serial: uint32, mimeType: string) =
@@ -61,12 +63,16 @@ func `onSourceActions=`*(offer: DataOffer, cb: DataOfferSourceActionsCallback) =
 func `onAction=`*(offer: DataOffer, cb: DataOfferActionCallback) =
   offer.payload.actionCb = cb
 
-proc attachCallbacks*(offer: DataOffer) =
-  discard wl_data_offer_add_listener(
-    offer.handle, listener.addr, cast[pointer](offer.payload)
-  )
+proc attachCallbacks*(offer: DataOffer) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".}
+  discard
 
 proc setActions*(offer: DataOffer, dndActions, preferredActions: set[DNDAction]) =
   wl_data_offer_set_actions(
     offer.handle, cast[uint32](dndActions), cast[uint32](preferredActions)
+  )
+
+proc newDataOffer*(handle: ptr wl_data_offer): DataOffer {.inline.} =
+  result = DataOffer(handle: handle, payload: DataOfferPayload())
+  discard wl_data_offer_add_listener(
+    result.handle, listener.addr, cast[pointer](result.payload)
   )

--- a/src/nayland/types/protocols/core/data_offer.nim
+++ b/src/nayland/types/protocols/core/data_offer.nim
@@ -63,7 +63,7 @@ func `onSourceActions=`*(offer: DataOffer, cb: DataOfferSourceActionsCallback) =
 func `onAction=`*(offer: DataOffer, cb: DataOfferActionCallback) =
   offer.payload.actionCb = cb
 
-proc attachCallbacks*(offer: DataOffer) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".}
+proc attachCallbacks*(offer: DataOffer) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".} =
   discard
 
 proc setActions*(offer: DataOffer, dndActions, preferredActions: set[DNDAction]) =

--- a/src/nayland/types/protocols/core/data_source.nim
+++ b/src/nayland/types/protocols/core/data_source.nim
@@ -89,7 +89,7 @@ func `onDndFinished=`*(source: DataSource, cb: DataSourceDNDFinishedCallback) =
 func `onAction=`*(source: DataSource, cb: DataSourceActionCallback) =
   source.payload.actionCb = cb
 
-proc attachCallbacks*(source: DataSource) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".}
+proc attachCallbacks*(source: DataSource) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".} =
   discard
 
 proc offer*(source: DataSource, mime: string) =

--- a/src/nayland/types/protocols/core/data_source.nim
+++ b/src/nayland/types/protocols/core/data_source.nim
@@ -36,32 +36,37 @@ type
 proc `=destroy`*(source: DataSourceObj) =
   wl_data_source_destroy(source.handle)
 
-func newDataSource*(handle: ptr wl_data_source): DataSource {.inline.} =
-  DataSource(handle: handle, payload: DatasourcePayload())
+proc newDataSource*(handle: ptr wl_data_source): DataSource {.inline.}
 
 let listener = wl_data_source_listener(
   target: proc(
       data: pointer, source: ptr wl_data_source, mimeType: ConstCStr
   ) {.cdecl.} =
     let payload = cast[DataSourcePayload](data)
-    payload.targetCb(newDataSource(source), $mimeType),
+    if payload.targetCb != nil:
+      payload.targetCb(newDataSource(source), $mimeType),
   send: proc(
       data: pointer, source: ptr wl_data_source, mimeType: ConstCStr, fd: int32
   ) {.cdecl.} =
     let payload = cast[DataSourcePayload](data)
-    payload.sendCb(newDataSource(source), $mimeType, fd),
+    if payload.sendCb != nil:
+      payload.sendCb(newDataSource(source), $mimeType, fd),
   cancelled: proc(data: pointer, source: ptr wl_data_source) {.cdecl.} =
     let payload = cast[DataSourcePayload](data)
-    payload.cancelledCb(newDataSource(source)),
+    if payload.cancelledCb != nil:
+      payload.cancelledCb(newDataSource(source)),
   dnd_drop_performed: proc(data: pointer, source: ptr wl_data_source) {.cdecl.} =
     let payload = cast[DataSourcePayload](data)
-    payload.dndDropPerformedCb(newDataSource(source)),
+    if payload.dndDropPerformedCb != nil:
+      payload.dndDropPerformedCb(newDataSource(source)),
   dnd_finished: proc(data: pointer, source: ptr wl_data_source) {.cdecl.} =
     let payload = cast[DataSourcePayload](data)
-    payload.dndFinishedCb(newDataSource(source)),
+    if payload.dndFinishedCb != nil:
+      payload.dndFinishedCb(newDataSource(source)),
   action: proc(data: pointer, source: ptr wl_data_source, dndAction: uint32) {.cdecl.} =
     let payload = cast[DataSourcePayload](data)
-    payload.actionCb(newDataSource(source), cast[DNDAction](dndAction)),
+    if payload.actionCb != nil:
+      payload.actionCb(newDataSource(source), cast[DNDAction](dndAction)),
 )
 
 func `onTarget=`*(source: DataSource, cb: DataSourceTargetCallback) =
@@ -84,13 +89,17 @@ func `onDndFinished=`*(source: DataSource, cb: DataSourceDNDFinishedCallback) =
 func `onAction=`*(source: DataSource, cb: DataSourceActionCallback) =
   source.payload.actionCb = cb
 
-proc attachCallbacks*(source: DataSource) =
-  discard wl_data_source_add_listener(
-    source.handle, listener.addr, cast[pointer](source.payload)
-  )
+proc attachCallbacks*(source: DataSource) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".}
+  discard
 
 proc offer*(source: DataSource, mime: string) =
   wl_data_source_offer(source.handle, cstring(mime))
 
 proc setActions*(source: DataSource, actions: set[DNDAction]) =
   wl_data_source_set_actions(source.handle, cast[uint32](actions))
+
+proc newDataSource*(handle: ptr wl_data_source): DataSource {.inline.} =
+  result = DataSource(handle: handle, payload: DatasourcePayload())
+  discard wl_data_source_add_listener(
+    result.handle, listener.addr, cast[pointer](result.payload)
+  )

--- a/src/nayland/types/protocols/core/keyboard.nim
+++ b/src/nayland/types/protocols/core/keyboard.nim
@@ -124,7 +124,7 @@ proc `onModifiers=`*(keyb: Keyboard, cb: KeyboardModifiersCallback) =
 proc `onRepeatInfo=`*(keyb: Keyboard, cb: KeyboardRepeatInfoCallback) =
   keyb.callbacks.repeatInfoCb = cb
 
-proc attachCallbacks*(keyb: Keyboard) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".} 
+proc attachCallbacks*(keyb: Keyboard) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".} =
   discard
 
 proc newKeyboard*(handle: ptr wl_keyboard): Keyboard =

--- a/src/nayland/types/protocols/core/keyboard.nim
+++ b/src/nayland/types/protocols/core/keyboard.nim
@@ -48,7 +48,8 @@ let listener = wl_keyboard_listener(
       data: pointer, keyb: ptr wl_keyboard, fmt: uint32, fd: int32, size: uint32
   ) {.cdecl.} =
     let payload = cast[ptr KeyboardCallbacksObj](data)
-    payload.keymapCb(payload.keyb, fmt, fd, size),
+    if payload.keymapCb != nil:
+      payload.keymapCb(payload.keyb, fmt, fd, size),
   enter: proc(
       data: pointer,
       keyb: ptr wl_keyboard,
@@ -56,19 +57,21 @@ let listener = wl_keyboard_listener(
       surf: ptr wl_surface,
       keys: ptr wl_array,
   ) {.cdecl.} =
-    let numKeys = int(keys.size.int / sizeof(uint32))
     let payload = cast[ptr KeyboardCallbacksObj](data)
-    var keysBuff = newSeq[uint32](numKeys)
+    if payload.enterCb != nil:
+      let numKeys = int(keys.size.int / sizeof(uint32))
+      var keysBuff = newSeq[uint32](numKeys)
 
-    if numKeys > 0:
-      copyMem(keysBuff[0].addr, cast[ptr uint32](keys), numKeys)
+      if numKeys > 0:
+        copyMem(keysBuff[0].addr, cast[ptr uint32](keys), numKeys)
 
-    payload.enterCb(payload.keyb, serial, newSurface(surf), ensureMove(keysBuff)),
+      payload.enterCb(payload.keyb, serial, newSurface(surf), ensureMove(keysBuff)),
   leave: proc(
       data: pointer, keyb: ptr wl_keyboard, serial: uint32, surf: ptr wl_surface
   ) {.cdecl.} =
     let payload = cast[ptr KeyboardCallbacksObj](data)
-    payload.leaveCb(payload.keyb, serial, newSurface(surf)),
+    if payload.leaveCb != nil:
+      payload.leaveCb(payload.keyb, serial, newSurface(surf)),
   key: proc(
       data: pointer,
       keyb: ptr wl_keyboard,
@@ -78,7 +81,8 @@ let listener = wl_keyboard_listener(
       state: uint32,
   ) {.cdecl.} =
     let payload = cast[ptr KeyboardCallbacksObj](data)
-    payload.keyCb(payload.keyb, serial, time, key, state),
+    if payload.keyCb != nil:
+      payload.keyCb(payload.keyb, serial, time, key, state),
   modifiers: proc(
       data: pointer,
       keyb: ptr wl_keyboard,
@@ -89,12 +93,14 @@ let listener = wl_keyboard_listener(
       group: uint32,
   ) {.cdecl.} =
     let payload = cast[ptr KeyboardCallbacksObj](data)
-    payload.modifiersCb(
-      payload.keyb, serial, modsDepressed, modsLatched, modsLocked, group
-    ),
+    if payload.modifiersCb != nil:
+      payload.modifiersCb(
+        payload.keyb, serial, modsDepressed, modsLatched, modsLocked, group
+      ),
   repeatInfo: proc(data: pointer, keyb: ptr wl_keyboard, rate, delay: int32) {.cdecl.} =
     let payload = cast[ptr KeyboardCallbacksObj](data)
-    payload.repeatInfoCb(payload.keyb, rate, delay),
+    if payload.repeatInfoCb != nil:
+      payload.repeatInfoCb(payload.keyb, rate, delay),
 )
 
 proc release*(keyb: Keyboard) =
@@ -118,10 +124,12 @@ proc `onModifiers=`*(keyb: Keyboard, cb: KeyboardModifiersCallback) =
 proc `onRepeatInfo=`*(keyb: Keyboard, cb: KeyboardRepeatInfoCallback) =
   keyb.callbacks.repeatInfoCb = cb
 
-proc attachCallbacks*(keyb: Keyboard) =
-  discard wl_keyboard_add_listener(
-    keyb.handle, listener.addr, cast[ptr KeyboardCallbacksObj](keyb.callbacks)
-  )
+proc attachCallbacks*(keyb: Keyboard) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".} 
+  discard
 
-func newKeyboard*(handle: ptr wl_keyboard): Keyboard =
-  Keyboard(handle: handle, callbacks: KeyboardCallbacks())
+proc newKeyboard*(handle: ptr wl_keyboard): Keyboard =
+  result = Keyboard(handle: handle, callbacks: KeyboardCallbacks())
+  result.callbacks.keyb = result
+  discard wl_keyboard_add_listener(
+    handle, listener.addr, cast[ptr KeyboardCallbacksObj](result.callbacks)
+  )

--- a/src/nayland/types/protocols/core/output.nim
+++ b/src/nayland/types/protocols/core/output.nim
@@ -128,7 +128,7 @@ func `onName=`*(output: Output, cb: OutputNameCallback) =
 func `onDescription=`*(output: Output, cb: OutputDescriptionCallback) =
   output.payload.descriptionCb = cb
 
-proc attachCallbacks*(output: Output) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".} 
+proc attachCallbacks*(output: Output) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".} =
   discard
 
 proc initOutput*(handle: pointer | ptr wl_output): Output {.inline.} =

--- a/src/nayland/types/protocols/core/output.nim
+++ b/src/nayland/types/protocols/core/output.nim
@@ -61,8 +61,7 @@ type
 proc release*(output: Output) =
   wl_output_release(output.handle)
 
-func initOutput*(handle: pointer | ptr wl_output): Output {.inline.} =
-  Output(handle: cast[ptr wl_output](handle), payload: OutputCallbackPayload())
+proc initOutput*(handle: pointer | ptr wl_output): Output {.inline.}
 
 let listener = wl_output_listener(
   geometry: proc(
@@ -73,36 +72,42 @@ let listener = wl_output_listener(
       transform: int32,
   ) {.cdecl.} =
     let payload = cast[OutputCallbackPayload](data)
-    payload.geometryCb(
-      initOutput(output),
-      x,
-      y,
-      physicalWidth,
-      physicalHeight,
-      cast[OutputSubpixel](subpixel),
-      $make,
-      $model,
-      cast[OutputTransform](transform),
-    ),
+    if payload.geometryCb != nil:
+      payload.geometryCb(
+        initOutput(output),
+        x,
+        y,
+        physicalWidth,
+        physicalHeight,
+        cast[OutputSubpixel](subpixel),
+        $make,
+        $model,
+        cast[OutputTransform](transform),
+      ),
   mode: proc(
       data: pointer, output: ptr wl_output, flags: uint32, width, height, refresh: int32
   ) {.cdecl.} =
     let payload = cast[OutputCallbackPayload](data)
-    payload.modeCb(
-      initOutput(output), cast[set[OutputMode]](flags), width, height, refresh
-    ),
+    if payload.modeCb != nil:
+      payload.modeCb(
+        initOutput(output), cast[set[OutputMode]](flags), width, height, refresh
+      ),
   done: proc(data: pointer, output: ptr wl_output) {.cdecl.} =
     let payload = cast[OutputCallbackPayload](data)
-    payload.doneCb(initOutput(output)),
+    if payload.doneCb != nil:
+      payload.doneCb(initOutput(output)),
   scale: proc(data: pointer, output: ptr wl_output, factor: int32) {.cdecl.} =
     let payload = cast[OutputCallbackPayload](data)
-    payload.scaleCb(initOutput(output), factor),
+    if payload.scaleCb != nil:
+      payload.scaleCb(initOutput(output), factor),
   name: proc(data: pointer, output: ptr wl_output, name: ConstCStr) {.cdecl.} =
     let payload = cast[OutputCallbackPayload](data)
-    payload.nameCb(initOutput(output), $name),
+    if payload.nameCb != nil:
+      payload.nameCb(initOutput(output), $name),
   description: proc(data: pointer, output: ptr wl_output, desc: ConstCStr) {.cdecl.} =
     let payload = cast[OutputCallbackPayload](data)
-    payload.descriptionCb(initOutput(output), $desc),
+    if payload.descriptionCb != nil:
+      payload.descriptionCb(initOutput(output), $desc),
 )
 
 func `onGeometry=`*(output: Output, cb: OutputGeometryCallback) =
@@ -123,6 +128,10 @@ func `onName=`*(output: Output, cb: OutputNameCallback) =
 func `onDescription=`*(output: Output, cb: OutputDescriptionCallback) =
   output.payload.descriptionCb = cb
 
-proc attachCallbacks*(output: Output) =
+proc attachCallbacks*(output: Output) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".} 
   discard
-    wl_output_add_listener(output.handle, listener.addr, cast[pointer](output.payload))
+
+proc initOutput*(handle: pointer | ptr wl_output): Output {.inline.} =
+  result = Output(handle: cast[ptr wl_output](handle), payload: OutputCallbackPayload())
+  discard
+    wl_output_add_listener(result.handle, listener.addr, cast[pointer](result.payload))

--- a/src/nayland/types/protocols/core/pointer.nim
+++ b/src/nayland/types/protocols/core/pointer.nim
@@ -61,53 +61,64 @@ let listener = wl_pointer_listener(
       surfaceX, surfaceY: wl_fixed,
   ) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.enterCb(
-      payload.obj, serial, newSurface(surf), surfaceX.toFloat(), surfaceY.toFloat()
-    ),
+    if payload.enterCb != nil:
+      payload.enterCb(
+        payload.obj, serial, newSurface(surf), surfaceX.toFloat(), surfaceY.toFloat()
+      ),
   leave: proc(
       data: pointer, _: ptr wl_pointer, serial: uint32, surf: ptr wl_surface
   ) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.leaveCb(payload.obj, serial, newSurface(surf)),
+    if payload.leaveCb != nil:
+      payload.leaveCb(payload.obj, serial, newSurface(surf)),
   motion: proc(
       data: pointer, _: ptr wl_pointer, time: uint32, surfaceX, surfaceY: wl_fixed
   ) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.motionCb(payload.obj, time, surfaceX.toFloat(), surfaceY.toFloat()),
+    if payload.motionCb != nil:
+      payload.motionCb(payload.obj, time, surfaceX.toFloat(), surfaceY.toFloat()),
   frame: proc(data: pointer, _: ptr wl_pointer) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.frameCb(payload.obj),
+    if payload.frameCb != nil:
+      payload.frameCb(payload.obj),
   axis: proc(
       data: pointer, _: ptr wl_pointer, time, axis: uint32, value: wl_fixed
   ) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.axisCb(payload.obj, time, axis, toFloat(value)),
+    if payload.axisCb != nil:
+      payload.axisCb(payload.obj, time, axis, toFloat(value)),
   button: proc(
       data: pointer, pntr: ptr wl_pointer, serial, time, button, state: uint32
   ) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.buttonCb(payload.obj, serial, time, button, cast[ButtonState](state)),
+    if payload.buttonCb != nil:
+      payload.buttonCb(payload.obj, serial, time, button, cast[ButtonState](state)),
   axis_stop: proc(data: pointer, pntr: ptr wl_pointer, time, axis: uint32) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.axisStopCb(payload.obj, time, axis),
+    if payload.axisStopCb != nil:
+      payload.axisStopCb(payload.obj, time, axis),
   axis_discrete: proc(
       data: pointer, pntr: ptr wl_pointer, axis: uint32, discrete: int32
   ) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.axisDiscreteCb(payload.obj, axis, discrete),
+    if payload.axisDiscreteCb != nil:
+      payload.axisDiscreteCb(payload.obj, axis, discrete),
   axis_value120: proc(
       data: pointer, pntr: ptr wl_pointer, axis: uint32, value120: int32
   ) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.axisValue120Cb(payload.obj, axis, value120),
+    if payload.axisValue120Cb != nil:
+      payload.axisValue120Cb(payload.obj, axis, value120),
   axis_source: proc(data: pointer, pntr: ptr wl_pointer, axisSource: uint32) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.axisSourceCb(payload.obj, axisSource),
+    if payload.axisSourceCb != nil:
+      payload.axisSourceCb(payload.obj, axisSource),
   axis_relative_direction: proc(
       data: pointer, pntr: ptr wl_pointer, axis, direction: uint32
   ) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.axisRelativeDirection(payload.obj, axis, direction),
+    if payload.axisRelativeDirection != nil:
+      payload.axisRelativeDirection(payload.obj, axis, direction),
 )
 
 proc release*(pntr: Pointer | PointerObj) =
@@ -148,12 +159,12 @@ proc `onAxisRelativeDirection=`*(
 ) =
   pntr.callbacks.axisRelativeDirection = callback
 
-proc attachCallbacks*(pntr: Pointer) =
-  pntr.callbacks.obj = pntr
+proc attachCallbacks*(pntr: Pointer) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".} =
+  discard
 
+proc newPointer*(handle: ptr wl_pointer): Pointer =
+  result = Pointer(handle: handle, callbacks: PointerCallbackPRef())
+  result.callbacks.obj = result
   discard wl_pointer_add_listener(
-    pntr.handle, listener.addr, cast[ptr PointerCallbackPayload](pntr.callbacks)
+    handle, listener.addr, cast[ptr PointerCallbackPayload](result.callbacks)
   )
-
-func newPointer*(handle: ptr wl_pointer): Pointer =
-  Pointer(handle: handle, callbacks: PointerCallbackPRef())

--- a/src/nayland/types/protocols/core/touch.nim
+++ b/src/nayland/types/protocols/core/touch.nim
@@ -31,8 +31,7 @@ type
 
   Touch* = ref TouchObj
 
-func newTouch*(handle: ptr wl_touch): Touch {.inline.} =
-  Touch(handle: handle, payload: TouchCallbacksPayload())
+proc newTouch*(handle: ptr wl_touch): Touch {.inline.}
 
 let listener = wl_touch_listener(
   down: proc(
@@ -45,35 +44,42 @@ let listener = wl_touch_listener(
       x, y: wl_fixed,
   ) {.cdecl.} =
     let payload = cast[TouchCallbacksPayload](data)
-    payload.downCb(
-      newTouch(touch), serial, time, newSurface(surface), id, x.toFloat(), y.toFloat()
-    ),
+    if payload.downCb != nil:
+      payload.downCb(
+        newTouch(touch), serial, time, newSurface(surface), id, x.toFloat(), y.toFloat()
+      ),
   up: proc(
       data: pointer, touch: ptr wl_touch, serial: uint32, time: uint32, id: int32
   ) {.cdecl.} =
     let payload = cast[TouchCallbacksPayload](data)
-    payload.upCb(newTouch(touch), serial, time, id),
+    if payload.upCb != nil:
+      payload.upCb(newTouch(touch), serial, time, id),
   motion: proc(
       data: pointer, touch: ptr wl_touch, time: uint32, id: int32, x, y: wl_fixed
   ) {.cdecl.} =
     let payload = cast[TouchCallbacksPayload](data)
-    payload.motionCb(newTouch(touch), time, id, x.toFloat(), y.toFloat()),
+    if payload.motionCb != nil:
+      payload.motionCb(newTouch(touch), time, id, x.toFloat(), y.toFloat()),
   frame: proc(data: pointer, touch: ptr wl_touch) {.cdecl.} =
     let payload = cast[TouchCallbacksPayload](data)
-    payload.frameCb(newTouch(touch)),
+    if payload.frameCb != nil:
+      payload.frameCb(newTouch(touch)),
   cancel: proc(data: pointer, touch: ptr wl_touch) {.cdecl.} =
     let payload = cast[TouchCallbacksPayload](data)
-    payload.cancelCb(newTouch(touch)),
+    if payload.cancelCb != nil:
+      payload.cancelCb(newTouch(touch)),
   shape: proc(
       data: pointer, touch: ptr wl_touch, id: int32, major, minor: wl_fixed
   ) {.cdecl.} =
     let payload = cast[TouchCallbacksPayload](data)
-    payload.shapeCb(newTouch(touch), id, major.toFloat(), minor.toFloat()),
+    if payload.shapeCb != nil:
+      payload.shapeCb(newTouch(touch), id, major.toFloat(), minor.toFloat()),
   orientation: proc(
       data: pointer, touch: ptr wl_touch, id: int32, orientation: wl_fixed
   ) {.cdecl.} =
     let payload = cast[TouchCallbacksPayload](data)
-    payload.orientationCb(newTouch(touch), id, orientation.toFloat()),
+    if payload.orientationCb != nil:
+      payload.orientationCb(newTouch(touch), id, orientation.toFloat()),
 )
 
 proc release*(touch: Touch) =
@@ -100,6 +106,10 @@ func `onShape=`*(touch: Touch, cb: TouchShapeCallback) =
 func `onOrientation=`*(touch: Touch, cb: TouchOrientationCallback) =
   touch.payload.orientationCb = cb
 
-proc attachCallbacks*(touch: Touch) =
+proc attachCallbacks*(touch: Touch) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".} 
   discard
-    wl_touch_add_listener(touch.handle, listener.addr, cast[pointer](touch.payload))
+
+proc newTouch*(handle: ptr wl_touch): Touch {.inline.} =
+  result = Touch(handle: handle, payload: TouchCallbacksPayload())
+  discard
+    wl_touch_add_listener(result.handle, listener.addr, cast[pointer](result.payload))

--- a/src/nayland/types/protocols/core/touch.nim
+++ b/src/nayland/types/protocols/core/touch.nim
@@ -106,7 +106,7 @@ func `onShape=`*(touch: Touch, cb: TouchShapeCallback) =
 func `onOrientation=`*(touch: Touch, cb: TouchOrientationCallback) =
   touch.payload.orientationCb = cb
 
-proc attachCallbacks*(touch: Touch) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".} 
+proc attachCallbacks*(touch: Touch) {.deprecated: "callbacks are attached automatically now; this call is a no-op and safe to remove".} =
   discard
 
 proc newTouch*(handle: ptr wl_touch): Touch {.inline.} =


### PR DESCRIPTION
The current implementation assumes that the client registers for all callbacks and does not check whether a callback is nil. This causes the application to crash if a callback is missing.

It is not uncommon for a client to be interested in only specific events (e.g., mouse pointer events); however, it currently has to
 register for all events.

This issue has now been resolved by checking whether a callback has
 actually been registered. Furthermore, the (undesirable) call to
attachCallbacks() is no longer required.

The client can now register for specific events only and is no longer required to provide a callback for every event.

attachCallback has been kept for backward compatibility but is deprecated.