### PR TITLE
Added guards checking if there are actually callbacks registered

### DIFF
--- a/src/nayland/types/protocols/core/data_device.nim
+++ b/src/nayland/types/protocols/core/data_device.nim
@@ -41,7 +41,8 @@ let listener = wl_data_device_listener(
       data: pointer, device: ptr wl_data_device, offer: ptr wl_data_offer
   ) {.cdecl.} =
     let payload = cast[DataDevicePayload](data)
-    payload.dataOfferCb(newDataDevice(device), newDataOffer(offer)),
+    if payload.dataOfferCb != nil:
+      payload.dataOfferCb(newDataDevice(device), newDataOffer(offer)),
   enter: proc(
       data: pointer,
       device: ptr wl_data_device,
@@ -51,30 +52,35 @@ let listener = wl_data_device_listener(
       offer: ptr wl_data_offer,
   ) {.cdecl.} =
     let payload = cast[DataDevicePayload](data)
-    payload.enterCb(
-      newDataDevice(device),
-      serial,
-      newSurface(surface),
-      x.toFloat(),
-      y.toFloat(),
-      newDataOffer(offer),
-    ),
+    if payload.enterCb != nil:
+      payload.enterCb(
+        newDataDevice(device),
+        serial,
+        newSurface(surface),
+        x.toFloat(),
+        y.toFloat(),
+        newDataOffer(offer),
+      ),
   leave: proc(data: pointer, device: ptr wl_data_device) {.cdecl.} =
     let payload = cast[DataDevicePayload](data)
-    payload.leaveCb(newDataDevice(device)),
+    if payload.leaveCb != nil:
+      payload.leaveCb(newDataDevice(device)),
   motion: proc(
       data: pointer, source: ptr wl_data_device, serial: uint32, x, y: wl_fixed
   ) {.cdecl.} =
     let payload = cast[DataDevicePayload](data)
-    payload.motionCb(newDataDevice(source), serial, x.toFloat(), y.toFloat()),
+    if payload.motionCb != nil:
+      payload.motionCb(newDataDevice(source), serial, x.toFloat(), y.toFloat()),
   drop: proc(data: pointer, source: ptr wl_data_device) {.cdecl.} =
     let payload = cast[DataDevicePayload](data)
-    payload.dropCb(newDataDevice(source)),
+    if payload.dropCb != nil:
+      payload.dropCb(newDataDevice(source)),
   selection: proc(
       data: pointer, source: ptr wl_data_device, offer: ptr wl_data_offer
   ) {.cdecl.} =
     let payload = cast[DataDevicePayload](data)
-    payload.selectionCb(newDataDevice(source), newDataOffer(offer)),
+    if payload.selectionCb != nil:
+      payload.selectionCb(newDataDevice(source), newDataOffer(offer)),
 )
 
 proc startDrag*(
@@ -112,3 +118,4 @@ proc attachCallbacks*(device: DataDevice) =
 
 proc release*(device: DataDevice) =
   wl_data_device_release(device.handle)
+

--- a/src/nayland/types/protocols/core/data_offer.nim
+++ b/src/nayland/types/protocols/core/data_offer.nim
@@ -32,15 +32,18 @@ func newDataOffer*(handle: ptr wl_data_offer): DataOffer {.inline.} =
 let listener = wl_data_offer_listener(
   offer: proc(data: pointer, offer: ptr wl_data_offer, mime: ConstCStr) {.cdecl.} =
     let payload = cast[DataOfferPayload](data)
-    payload.offerCb(newDataOffer(offer), $mime),
+    if payload.offerCb != nil:
+      payload.offerCb(newDataOffer(offer), $mime),
   source_actions: proc(
       data: pointer, offer: ptr wl_data_offer, actions: uint32
   ) {.cdecl.} =
     let payload = cast[DataOfferPayload](data)
-    payload.sourceActionsCb(newDataOffer(offer), cast[set[DNDAction]](actions)),
+    if payload.sourceActionsCb != nil:
+      payload.sourceActionsCb(newDataOffer(offer), cast[set[DNDAction]](actions)),
   action: proc(data: pointer, offer: ptr wl_data_offer, dndAction: uint32) {.cdecl.} =
     let payload = cast[DataOfferPayload](data)
-    payload.actionCb(newDataOffer(offer), cast[set[DNDAction]](dndAction)),
+    if payload.actionCb != nil:
+      payload.actionCb(newDataOffer(offer), cast[set[DNDAction]](dndAction)),
 )
 
 proc accept*(offer: DataOffer, serial: uint32, mimeType: string) =
@@ -70,3 +73,4 @@ proc setActions*(offer: DataOffer, dndActions, preferredActions: set[DNDAction])
   wl_data_offer_set_actions(
     offer.handle, cast[uint32](dndActions), cast[uint32](preferredActions)
   )
+

--- a/src/nayland/types/protocols/core/data_source.nim
+++ b/src/nayland/types/protocols/core/data_source.nim
@@ -44,24 +44,30 @@ let listener = wl_data_source_listener(
       data: pointer, source: ptr wl_data_source, mimeType: ConstCStr
   ) {.cdecl.} =
     let payload = cast[DataSourcePayload](data)
-    payload.targetCb(newDataSource(source), $mimeType),
+    if payload.targetCb != nil:
+      payload.targetCb(newDataSource(source), $mimeType),
   send: proc(
       data: pointer, source: ptr wl_data_source, mimeType: ConstCStr, fd: int32
   ) {.cdecl.} =
     let payload = cast[DataSourcePayload](data)
-    payload.sendCb(newDataSource(source), $mimeType, fd),
+    if payload.sendCb != nil:
+      payload.sendCb(newDataSource(source), $mimeType, fd),
   cancelled: proc(data: pointer, source: ptr wl_data_source) {.cdecl.} =
     let payload = cast[DataSourcePayload](data)
-    payload.cancelledCb(newDataSource(source)),
+    if payload.cancelledCb != nil:
+      payload.cancelledCb(newDataSource(source)),
   dnd_drop_performed: proc(data: pointer, source: ptr wl_data_source) {.cdecl.} =
     let payload = cast[DataSourcePayload](data)
-    payload.dndDropPerformedCb(newDataSource(source)),
+    if payload.dndDropPerformedCb != nil:
+      payload.dndDropPerformedCb(newDataSource(source)),
   dnd_finished: proc(data: pointer, source: ptr wl_data_source) {.cdecl.} =
     let payload = cast[DataSourcePayload](data)
-    payload.dndFinishedCb(newDataSource(source)),
+    if payload.dndFinishedCb != nil:
+      payload.dndFinishedCb(newDataSource(source)),
   action: proc(data: pointer, source: ptr wl_data_source, dndAction: uint32) {.cdecl.} =
     let payload = cast[DataSourcePayload](data)
-    payload.actionCb(newDataSource(source), cast[DNDAction](dndAction)),
+    if payload.actionCb != nil:
+      payload.actionCb(newDataSource(source), cast[DNDAction](dndAction)),
 )
 
 func `onTarget=`*(source: DataSource, cb: DataSourceTargetCallback) =
@@ -94,3 +100,4 @@ proc offer*(source: DataSource, mime: string) =
 
 proc setActions*(source: DataSource, actions: set[DNDAction]) =
   wl_data_source_set_actions(source.handle, cast[uint32](actions))
+

--- a/src/nayland/types/protocols/core/keyboard.nim
+++ b/src/nayland/types/protocols/core/keyboard.nim
@@ -48,7 +48,8 @@ let listener = wl_keyboard_listener(
       data: pointer, keyb: ptr wl_keyboard, fmt: uint32, fd: int32, size: uint32
   ) {.cdecl.} =
     let payload = cast[ptr KeyboardCallbacksObj](data)
-    payload.keymapCb(payload.keyb, fmt, fd, size),
+    if payload.keymapCb != nil:
+      payload.keymapCb(payload.keyb, fmt, fd, size),
   enter: proc(
       data: pointer,
       keyb: ptr wl_keyboard,
@@ -56,19 +57,21 @@ let listener = wl_keyboard_listener(
       surf: ptr wl_surface,
       keys: ptr wl_array,
   ) {.cdecl.} =
-    let numKeys = int(keys.size.int / sizeof(uint32))
     let payload = cast[ptr KeyboardCallbacksObj](data)
-    var keysBuff = newSeq[uint32](numKeys)
+    if payload.enterCb != nil:
+      let numKeys = int(keys.size.int / sizeof(uint32))
+      var keysBuff = newSeq[uint32](numKeys)
 
-    if numKeys > 0:
-      copyMem(keysBuff[0].addr, cast[ptr uint32](keys), numKeys)
+      if numKeys > 0:
+        copyMem(keysBuff[0].addr, cast[ptr uint32](keys), numKeys)
 
-    payload.enterCb(payload.keyb, serial, newSurface(surf), ensureMove(keysBuff)),
+      payload.enterCb(payload.keyb, serial, newSurface(surf), ensureMove(keysBuff)),
   leave: proc(
       data: pointer, keyb: ptr wl_keyboard, serial: uint32, surf: ptr wl_surface
   ) {.cdecl.} =
     let payload = cast[ptr KeyboardCallbacksObj](data)
-    payload.leaveCb(payload.keyb, serial, newSurface(surf)),
+    if payload.leaveCb != nil:
+      payload.leaveCb(payload.keyb, serial, newSurface(surf)),
   key: proc(
       data: pointer,
       keyb: ptr wl_keyboard,
@@ -78,7 +81,8 @@ let listener = wl_keyboard_listener(
       state: uint32,
   ) {.cdecl.} =
     let payload = cast[ptr KeyboardCallbacksObj](data)
-    payload.keyCb(payload.keyb, serial, time, key, state),
+    if payload.keyCb != nil:
+      payload.keyCb(payload.keyb, serial, time, key, state),
   modifiers: proc(
       data: pointer,
       keyb: ptr wl_keyboard,
@@ -89,12 +93,14 @@ let listener = wl_keyboard_listener(
       group: uint32,
   ) {.cdecl.} =
     let payload = cast[ptr KeyboardCallbacksObj](data)
-    payload.modifiersCb(
-      payload.keyb, serial, modsDepressed, modsLatched, modsLocked, group
-    ),
+    if payload.modifiersCb != nil:
+      payload.modifiersCb(
+        payload.keyb, serial, modsDepressed, modsLatched, modsLocked, group
+      ),
   repeatInfo: proc(data: pointer, keyb: ptr wl_keyboard, rate, delay: int32) {.cdecl.} =
     let payload = cast[ptr KeyboardCallbacksObj](data)
-    payload.repeatInfoCb(payload.keyb, rate, delay),
+    if payload.repeatInfoCb != nil:
+      payload.repeatInfoCb(payload.keyb, rate, delay),
 )
 
 proc release*(keyb: Keyboard) =
@@ -119,9 +125,11 @@ proc `onRepeatInfo=`*(keyb: Keyboard, cb: KeyboardRepeatInfoCallback) =
   keyb.callbacks.repeatInfoCb = cb
 
 proc attachCallbacks*(keyb: Keyboard) =
+  keyb.callbacks.keyb = keyb
   discard wl_keyboard_add_listener(
     keyb.handle, listener.addr, cast[ptr KeyboardCallbacksObj](keyb.callbacks)
   )
 
 func newKeyboard*(handle: ptr wl_keyboard): Keyboard =
   Keyboard(handle: handle, callbacks: KeyboardCallbacks())
+

--- a/src/nayland/types/protocols/core/output.nim
+++ b/src/nayland/types/protocols/core/output.nim
@@ -73,36 +73,42 @@ let listener = wl_output_listener(
       transform: int32,
   ) {.cdecl.} =
     let payload = cast[OutputCallbackPayload](data)
-    payload.geometryCb(
-      initOutput(output),
-      x,
-      y,
-      physicalWidth,
-      physicalHeight,
-      cast[OutputSubpixel](subpixel),
-      $make,
-      $model,
-      cast[OutputTransform](transform),
-    ),
+    if payload.geometryCb != nil:
+      payload.geometryCb(
+        initOutput(output),
+        x,
+        y,
+        physicalWidth,
+        physicalHeight,
+        cast[OutputSubpixel](subpixel),
+        $make,
+        $model,
+        cast[OutputTransform](transform),
+      ),
   mode: proc(
       data: pointer, output: ptr wl_output, flags: uint32, width, height, refresh: int32
   ) {.cdecl.} =
     let payload = cast[OutputCallbackPayload](data)
-    payload.modeCb(
-      initOutput(output), cast[set[OutputMode]](flags), width, height, refresh
-    ),
+    if payload.modeCb != nil:
+      payload.modeCb(
+        initOutput(output), cast[set[OutputMode]](flags), width, height, refresh
+      ),
   done: proc(data: pointer, output: ptr wl_output) {.cdecl.} =
     let payload = cast[OutputCallbackPayload](data)
-    payload.doneCb(initOutput(output)),
+    if payload.doneCb != nil:
+      payload.doneCb(initOutput(output)),
   scale: proc(data: pointer, output: ptr wl_output, factor: int32) {.cdecl.} =
     let payload = cast[OutputCallbackPayload](data)
-    payload.scaleCb(initOutput(output), factor),
+    if payload.scaleCb != nil:
+      payload.scaleCb(initOutput(output), factor),
   name: proc(data: pointer, output: ptr wl_output, name: ConstCStr) {.cdecl.} =
     let payload = cast[OutputCallbackPayload](data)
-    payload.nameCb(initOutput(output), $name),
+    if payload.nameCb != nil:
+      payload.nameCb(initOutput(output), $name),
   description: proc(data: pointer, output: ptr wl_output, desc: ConstCStr) {.cdecl.} =
     let payload = cast[OutputCallbackPayload](data)
-    payload.descriptionCb(initOutput(output), $desc),
+    if payload.descriptionCb != nil:
+      payload.descriptionCb(initOutput(output), $desc),
 )
 
 func `onGeometry=`*(output: Output, cb: OutputGeometryCallback) =
@@ -126,3 +132,4 @@ func `onDescription=`*(output: Output, cb: OutputDescriptionCallback) =
 proc attachCallbacks*(output: Output) =
   discard
     wl_output_add_listener(output.handle, listener.addr, cast[pointer](output.payload))
+

--- a/src/nayland/types/protocols/core/pointer.nim
+++ b/src/nayland/types/protocols/core/pointer.nim
@@ -61,53 +61,64 @@ let listener = wl_pointer_listener(
       surfaceX, surfaceY: wl_fixed,
   ) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.enterCb(
-      payload.obj, serial, newSurface(surf), surfaceX.toFloat(), surfaceY.toFloat()
-    ),
+    if payload.enterCb != nil:
+      payload.enterCb(
+        payload.obj, serial, newSurface(surf), surfaceX.toFloat(), surfaceY.toFloat()
+      ),
   leave: proc(
       data: pointer, _: ptr wl_pointer, serial: uint32, surf: ptr wl_surface
   ) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.leaveCb(payload.obj, serial, newSurface(surf)),
+    if payload.leaveCb != nil:
+      payload.leaveCb(payload.obj, serial, newSurface(surf)),
   motion: proc(
       data: pointer, _: ptr wl_pointer, time: uint32, surfaceX, surfaceY: wl_fixed
   ) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.motionCb(payload.obj, time, surfaceX.toFloat(), surfaceY.toFloat()),
+    if payload.motionCb != nil:
+      payload.motionCb(payload.obj, time, surfaceX.toFloat(), surfaceY.toFloat()),
   frame: proc(data: pointer, _: ptr wl_pointer) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.frameCb(payload.obj),
+    if payload.frameCb != nil:
+      payload.frameCb(payload.obj),
   axis: proc(
       data: pointer, _: ptr wl_pointer, time, axis: uint32, value: wl_fixed
   ) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.axisCb(payload.obj, time, axis, toFloat(value)),
+    if payload.axisCb != nil:
+      payload.axisCb(payload.obj, time, axis, toFloat(value)),
   button: proc(
       data: pointer, pntr: ptr wl_pointer, serial, time, button, state: uint32
   ) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.buttonCb(payload.obj, serial, time, button, cast[ButtonState](state)),
+    if payload.buttonCb != nil:
+      payload.buttonCb(payload.obj, serial, time, button, cast[ButtonState](state)),
   axis_stop: proc(data: pointer, pntr: ptr wl_pointer, time, axis: uint32) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.axisStopCb(payload.obj, time, axis),
+    if payload.axisStopCb != nil:
+      payload.axisStopCb(payload.obj, time, axis),
   axis_discrete: proc(
       data: pointer, pntr: ptr wl_pointer, axis: uint32, discrete: int32
   ) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.axisDiscreteCb(payload.obj, axis, discrete),
+    if payload.axisDiscreteCb != nil:
+      payload.axisDiscreteCb(payload.obj, axis, discrete),
   axis_value120: proc(
       data: pointer, pntr: ptr wl_pointer, axis: uint32, value120: int32
   ) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.axisValue120Cb(payload.obj, axis, value120),
+    if payload.axisValue120Cb != nil:
+      payload.axisValue120Cb(payload.obj, axis, value120),
   axis_source: proc(data: pointer, pntr: ptr wl_pointer, axisSource: uint32) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.axisSourceCb(payload.obj, axisSource),
+    if payload.axisSourceCb != nil:
+      payload.axisSourceCb(payload.obj, axisSource),
   axis_relative_direction: proc(
       data: pointer, pntr: ptr wl_pointer, axis, direction: uint32
   ) {.cdecl.} =
     let payload = cast[ptr PointerCallbackPayload](data)
-    payload.axisRelativeDirection(payload.obj, axis, direction),
+    if payload.axisRelativeDirection != nil:
+      payload.axisRelativeDirection(payload.obj, axis, direction),
 )
 
 proc release*(pntr: Pointer | PointerObj) =
@@ -150,10 +161,10 @@ proc `onAxisRelativeDirection=`*(
 
 proc attachCallbacks*(pntr: Pointer) =
   pntr.callbacks.obj = pntr
-
   discard wl_pointer_add_listener(
     pntr.handle, listener.addr, cast[ptr PointerCallbackPayload](pntr.callbacks)
   )
 
 func newPointer*(handle: ptr wl_pointer): Pointer =
   Pointer(handle: handle, callbacks: PointerCallbackPRef())
+

--- a/src/nayland/types/protocols/core/touch.nim
+++ b/src/nayland/types/protocols/core/touch.nim
@@ -45,35 +45,42 @@ let listener = wl_touch_listener(
       x, y: wl_fixed,
   ) {.cdecl.} =
     let payload = cast[TouchCallbacksPayload](data)
-    payload.downCb(
-      newTouch(touch), serial, time, newSurface(surface), id, x.toFloat(), y.toFloat()
-    ),
+    if payload.downCb != nil:
+      payload.downCb(
+        newTouch(touch), serial, time, newSurface(surface), id, x.toFloat(), y.toFloat()
+      ),
   up: proc(
       data: pointer, touch: ptr wl_touch, serial: uint32, time: uint32, id: int32
   ) {.cdecl.} =
     let payload = cast[TouchCallbacksPayload](data)
-    payload.upCb(newTouch(touch), serial, time, id),
+    if payload.upCb != nil:
+      payload.upCb(newTouch(touch), serial, time, id),
   motion: proc(
       data: pointer, touch: ptr wl_touch, time: uint32, id: int32, x, y: wl_fixed
   ) {.cdecl.} =
     let payload = cast[TouchCallbacksPayload](data)
-    payload.motionCb(newTouch(touch), time, id, x.toFloat(), y.toFloat()),
+    if payload.motionCb != nil:
+      payload.motionCb(newTouch(touch), time, id, x.toFloat(), y.toFloat()),
   frame: proc(data: pointer, touch: ptr wl_touch) {.cdecl.} =
     let payload = cast[TouchCallbacksPayload](data)
-    payload.frameCb(newTouch(touch)),
+    if payload.frameCb != nil:
+      payload.frameCb(newTouch(touch)),
   cancel: proc(data: pointer, touch: ptr wl_touch) {.cdecl.} =
     let payload = cast[TouchCallbacksPayload](data)
-    payload.cancelCb(newTouch(touch)),
+    if payload.cancelCb != nil:
+      payload.cancelCb(newTouch(touch)),
   shape: proc(
       data: pointer, touch: ptr wl_touch, id: int32, major, minor: wl_fixed
   ) {.cdecl.} =
     let payload = cast[TouchCallbacksPayload](data)
-    payload.shapeCb(newTouch(touch), id, major.toFloat(), minor.toFloat()),
+    if payload.shapeCb != nil:
+      payload.shapeCb(newTouch(touch), id, major.toFloat(), minor.toFloat()),
   orientation: proc(
       data: pointer, touch: ptr wl_touch, id: int32, orientation: wl_fixed
   ) {.cdecl.} =
     let payload = cast[TouchCallbacksPayload](data)
-    payload.orientationCb(newTouch(touch), id, orientation.toFloat()),
+    if payload.orientationCb != nil:
+      payload.orientationCb(newTouch(touch), id, orientation.toFloat()),
 )
 
 proc release*(touch: Touch) =
@@ -103,3 +110,4 @@ func `onOrientation=`*(touch: Touch, cb: TouchOrientationCallback) =
 proc attachCallbacks*(touch: Touch) =
   discard
     wl_touch_add_listener(touch.handle, listener.addr, cast[pointer](touch.payload))
+


### PR DESCRIPTION
The current implementation assumes that the client registers for all callbacks and does not check whether a callback is nil. This causes the application to crash if a callback is missing.

It is not uncommon for a client to be interested in only specific events (e.g., pointer events); however, it currently has to register for all events.

This issue has now been resolved by checking whether a callback has actually been registered.

The client can now register for specific events only and is no longer required to provide a callback for every event.