### PR TITLE
Added Seat callbacks: name and capabilities

### DIFF
--- a/src/nayland/bindings/protocols/core.nim
+++ b/src/nayland/bindings/protocols/core.nim
@@ -77,7 +77,7 @@ type
   wl_seat_listener* {.importc: "struct $1".} = object
     capabilities*:
       proc(data: pointer, seat: ptr wl_seat, capabilities: uint32) {.cdecl.}
-    name*: proc(data: pointer, seat: ptr wl_seat, name: cstring) {.cdecl.}
+    name*: proc(data: pointer, seat: ptr wl_seat, name: ConstCStr) {.cdecl.}
 
   wl_keyboard_listener* {.importc: "struct $1".} = object
     keymap*: proc(

--- a/src/nayland/types/protocols/core/seat.nim
+++ b/src/nayland/types/protocols/core/seat.nim
@@ -6,8 +6,23 @@ import pkg/nayland/bindings/libwayland, pkg/nayland/bindings/protocols/core
 import pkg/nayland/types/protocols/core/[keyboard, pointer, touch]
 
 type
+  SeatCapability* {.pure, size: sizeof(uint32).} = enum
+    Pointer = 0x1
+    Keyboard = 0x2
+    Touch = 0x4
+
+  SeatCapabilitiesCallback = proc(seat: Seat, capabilities: set[SeatCapability])
+  SeatNameCallback = proc(seat: Seat, name: string)
+
+  SeatCallbackPObj = object
+    capabilitiesCb: SeatCapabilitiesCallback
+    nameCb: SeatNameCallback
+
+  SeatCallbackPayload = ref SeatCallbackPObj
+
   SeatObj = object
     handle*: ptr wl_seat
+    payload: SeatCallbackPayload
 
   Seat* = ref SeatObj
 
@@ -16,6 +31,26 @@ proc release*(seat: Seat) =
 
   # if you wish to destroy the seat, place enrico weigelt on top of it instead
   wl_seat_release(seat.handle)
+
+let listener = wl_seat_listener(
+  capabilities: proc(data: pointer, seat: ptr wl_seat, capabilities: uint32) {.cdecl.} =
+    let payload = cast[SeatCallbackPayload](data)
+    if payload.capabilitiesCb != nil:
+      payload.capabilitiesCb(
+        Seat(handle: seat, payload: payload), cast[set[SeatCapability]](capabilities)
+      ),
+  name: proc(data: pointer, seat: ptr wl_seat, name: ConstCStr) {.cdecl.} =
+    let payload = cast[SeatCallbackPayload](data)
+    if payload.nameCb != nil:
+      payload.nameCb(Seat(handle: seat, payload: payload), $name),
+)
+
+func `onCapabilities=`*(seat: Seat, cb: SeatCapabilitiesCallback) =
+  seat.payload.capabilitiesCb = cb
+
+func `onName=`*(seat: Seat, cb: SeatNameCallback) =
+  seat.payload.nameCb = cb
+
 
 proc getPointer*(seat: Seat): Option[Pointer] =
   let handle = wl_seat_get_pointer(seat.handle)
@@ -38,5 +73,9 @@ proc getTouch*(seat: Seat): Option[Touch] =
 
   some(newTouch(handle))
 
+proc attachCallbacks*(seat: Seat) =
+  discard wl_seat_add_listener(seat.handle, listener.addr, cast[pointer](seat.payload))
+
 func initSeat*(handle: pointer): Seat =
-  Seat(handle: cast[ptr wl_seat](handle))
+  Seat(handle: cast[ptr wl_seat](handle), payload: SeatCallbackPayload())
+


### PR DESCRIPTION
Added Seat callbacks for name and capabilities.
Fixed bug in bindings/core: The wl_seat_listener used cstring instead of ConstCStr for the name parameter.